### PR TITLE
:bug: The application name is now `validate-json`

### DIFF
--- a/jsonvalidator/validate_json.py
+++ b/jsonvalidator/validate_json.py
@@ -71,7 +71,7 @@ def make_command_line_parser(prog: str) -> ArgumentParser:
     Return a parser for the command line
     """
 
-    parser = ArgumentParser(prog=prog)
+    parser = ArgumentParser(prog=Path(prog).name)
 
     parser.add_argument(
         "--data-path",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,14 @@ dependencies = [
 
 ]
 
+[project.scripts]
+validate-json = "jsonvalidator:validate_json_app"
+
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry.scripts]
-my-script = "jsonvalidator:validate_json_app"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.16.0"


### PR DESCRIPTION
Problem:
- The application was named `my-script` in `pyproject.tom`.
- The program name for the command line parser produces the absolution path, rather than the name of the application

Solution:
- Set the correct script name in `pyproject.toml`
- Extract the name from the full path for the command line parser.